### PR TITLE
Yaml test

### DIFF
--- a/analyze_source_files.sh
+++ b/analyze_source_files.sh
@@ -10,7 +10,6 @@ list_dir=(*)
 
 declare -a source_folders
 for f in ${list_dir[@]}; do
-    # Filter out EX1, EX2 and files from list_dir
     if [ -d "$f" ] ; then
         cd $f
         echo "## Found source folder: ${f}"

--- a/analyze_source_files.sh
+++ b/analyze_source_files.sh
@@ -10,13 +10,13 @@ list_dir=(*)
 
 declare -a source_folders
 for f in ${list_dir[@]}; do
-    if [ -d "$f" ] ; then
-        cd $f
-        echo "## Found source folder: ${f}"
-        # Add source folders to array
-        source_folders+=("$f")
-        cd ..
-    fi
+  if [ -d "$f" ]; then
+    cd $f
+    echo "## Found source folder: ${f}"
+    # Add source folders to array
+    source_folders+=("$f")
+    cd ..
+  fi
 done
 
 # Save array to workspace to persist data between steps

--- a/analyze_source_files.sh
+++ b/analyze_source_files.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Exit on error
 set -e
-# Folders to exclude
-EX1="pipelines"
 
 # Use source_data folder as cwd
 cd /workspace/automation/source_data/
@@ -13,7 +11,7 @@ list_dir=(*)
 declare -a source_folders
 for f in ${list_dir[@]}; do
     # Filter out EX1, EX2 and files from list_dir
-    if [ -d "$f" ] && [ "$f" != "$EX1" ] ; then
+    if [ -d "$f" ] ; then
         cd $f
         echo "## Found source folder: ${f}"
         # Add source folders to array

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 dapla-toolbelt
 pytest
 pyflakes
+PyYAML

--- a/tests/test-plugins/test_plugins.py
+++ b/tests/test-plugins/test_plugins.py
@@ -4,9 +4,9 @@ from plugins import load_plugins
 
 
 def test_main_accepts_expected_number_of_args():
-    """Checks that plugins in a source_folder contains a main function and accepts the expected number of arguments."""
+    """Loads the plugin and checks that it has a main function that accepts the expected number of arguments."""
     plugins = load_plugins()
     for plugin in plugins:
         assert hasattr(plugin, "main")
-        assert len(['file_path', 'file_name', '_source_bucket', 'destination_bucket']) == len(
+        assert len(['file_path']) == len(
             signature(plugin.main).parameters.values())

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+import yaml
 
 PATH = Path("/workspace/automation/source_data")
 
@@ -28,12 +29,11 @@ class TestProjectStructure(unittest.TestCase):
             yaml_files = [f for f in os.listdir(source_dir) if 'config.yaml' in str(f)]
             # Check that config.yaml is in source directory
             assert len(yaml_files) == 1
-
-            with open(PATH / source_dir / Path(yaml_files[0])) as yaml:
-                data = yaml.read()
-            # List all folder prefixes from config.yaml
-            folder_prefixs = re.findall(r'(folder_prefix: [a-zA-Z0-9_/-]*)', data)
-            assert len(folder_prefixs) == 1
+            with open(PATH / source_dir / Path(yaml_files[0]), 'r') as f:
+                data = yaml.safe_load(f)
+            # Check that folder_prefix exclusively contains allowed chars
+            matches = re.findall(r"^[A-Za-z0-9-_./]+$", data['folder_prefix'])
+            assert len(matches) == 1
 
     def test_source_script_main_accepts_args(self):
         """Checks that every source folder plugin has main function and accepts required number of arguments.


### PR DESCRIPTION
- Add test for config.yaml file, checking that every source folder has one.
- Check that trigger definition exclusively contains allowed chars(A-Za-z0-9-_./).
- Update test of main function in user supplied script, main function now takes exactly one argument.
- Pipelines folder is no longer excluded.
- Removed test_sources_in_tfvars