### PR TITLE
Add variable for choosing staging environment

### DIFF
--- a/analyze_source_files.sh
+++ b/analyze_source_files.sh
@@ -12,7 +12,7 @@ python -m pip install -r requirements.txt
 pytest
 echo " ## No errors found by pytest"
 # Check code with pyflakes
-cd /workspace/automation/source_data/$FOLDER_NAME
-echo "## Checking code with pyflakes: ${FOLDER_NAME}"
+cd /workspace/automation/source_data/$FOLDER_NAME/$ENV_NAME
+echo "## Checking code with pyflakes: ${FOLDER_NAME} in environment:${ENV_NAME}"
 pyflakes process_source_data.py
 echo " ## No errors found by pyflakes"

--- a/analyze_source_files.sh
+++ b/analyze_source_files.sh
@@ -12,7 +12,7 @@ python -m pip install -r requirements.txt
 pytest
 echo " ## No errors found by pytest"
 # Check code with pyflakes
-cd /workspace/automation/source_data/$FOLDER_NAME/$ENV_NAME
+cd /workspace/automation/source_data/$ENV_NAME/$FOLDER_NAME
 echo "## Checking code with pyflakes: ${FOLDER_NAME} in environment:${ENV_NAME}"
 pyflakes process_source_data.py
 echo " ## No errors found by pyflakes"

--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -7,7 +7,7 @@
 set -e
 
 # Build and push docker images for each source folder
-cd /workspace/automation/source_data/$FOLDER_NAME/$ENV_NAME
+cd /workspace/automation/source_data/$ENV_NAME/$FOLDER_NAME
 # Create docker file
 echo $'FROM europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/base-image:prod\nCOPY . ./plugins' >Dockerfile
 

--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -7,21 +7,21 @@
 set -e
 
 # Build and push docker images for each source folder
-cd /workspace/automation/source_data/$FOLDER_NAME
+cd /workspace/automation/source_data/$FOLDER_NAME/$ENV_NAME
 # Create docker file
 echo $'FROM europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/base-image:prod\nCOPY . ./plugins' >Dockerfile
 
-echo "## Building image for: ${FOLDER_NAME}"
+echo "## Building image for: ${FOLDER_NAME} in environment:${ENV_NAME}"
 set +e
-docker build . -t europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/$TEAM_NAME/$FOLDER_NAME:prod
+docker build . -t europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/$TEAM_NAME/$FOLDER_NAME:$ENV_NAME
 docker_build_ret=$?
 set -e
 if [ $docker_build_ret -ne 0 ]; then exit $docker_build_ret; fi
 
 
-echo "## Pushing image: ${FOLDER_NAME}"
+echo "## Pushing image: ${FOLDER_NAME} in environment:${ENV_NAME}"
 set +e
-docker push europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/$TEAM_NAME/$FOLDER_NAME:prod
+docker push europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/$TEAM_NAME/$FOLDER_NAME:$ENV_NAME
 docker_push_ret=$?
 set -e
 if [ $docker_push_ret -ne 0 ]; then exit $docker_push_ret; fi

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -14,7 +14,8 @@ class TestProjectStructure(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         source_folder = os.environ.get('FOLDER_NAME')
-        cls.source_folder_path = Path(f"/workspace/automation/source_data/{source_folder}")
+        env_name = os.environ.get('ENV_NAME')
+        cls.source_folder_path = Path(f"/workspace/automation/source_data/{source_folder}/{env_name}")
 
     def test_source_folder_include_python_script(self):
         """Checks if source folder contains a .py file."""

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -15,7 +15,7 @@ class TestProjectStructure(unittest.TestCase):
     def setUpClass(cls):
         source_folder = os.environ.get('FOLDER_NAME')
         env_name = os.environ.get('ENV_NAME')
-        cls.source_folder_path = Path(f"/workspace/automation/source_data/{source_folder}/{env_name}")
+        cls.source_folder_path = Path(f"/workspace/automation/source_data/{env_name}/{source_folder}")
 
     def test_source_folder_include_python_script(self):
         """Checks if source folder contains a .py file."""

--- a/update_cloud_run_images.sh
+++ b/update_cloud_run_images.sh
@@ -10,7 +10,7 @@ cd /workspace/automation/source_data/$ENV_NAME/$FOLDER_NAME
 echo "## Updating image used by cloud run for: ${FOLDER_NAME} in environment:${ENV_NAME}"
 
 set +e
-gcloud run deploy $PROCESSOR_NAME --image europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/$TEAM_NAME/$FOLDER_NAME:$ENV_NAME --region europe-north1
+gcloud run deploy $PROCESSOR_NAME --image europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/$TEAM_NAME/$FOLDER_NAME:$ENV_NAME --region europe-north1 --project $PROJECT_ID
 gcloud_ret=$?
 set -e
 if [ $gcloud_ret -ne 0 ]; then exit $gcloud_ret; fi

--- a/update_cloud_run_images.sh
+++ b/update_cloud_run_images.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Update image used by every cloud run for source_folder.
-cd /workspace/automation/source_data/$FOLDER_NAME/$ENV_NAME
+cd /workspace/automation/source_data/$ENV_NAME/$FOLDER_NAME
 echo "## Updating image used by cloud run for: ${FOLDER_NAME} in environment:${ENV_NAME}"
 
 set +e

--- a/update_cloud_run_images.sh
+++ b/update_cloud_run_images.sh
@@ -6,11 +6,11 @@
 set -e
 
 # Update image used by every cloud run for source_folder.
-cd /workspace/automation/source_data/$FOLDER_NAME
-echo "## Updating image used by cloud run for: ${FOLDER_NAME}"
+cd /workspace/automation/source_data/$FOLDER_NAME/$ENV_NAME
+echo "## Updating image used by cloud run for: ${FOLDER_NAME} in environment:${ENV_NAME}"
 
 set +e
-gcloud run deploy $PROCESSOR_NAME --image europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/$TEAM_NAME/$FOLDER_NAME:prod --region europe-north1
+gcloud run deploy $PROCESSOR_NAME --image europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/source_data/$TEAM_NAME/$FOLDER_NAME:$ENV_NAME --region europe-north1
 gcloud_ret=$?
 set -e
 if [ $gcloud_ret -ne 0 ]; then exit $gcloud_ret; fi


### PR DESCRIPTION
Add support for staging environment. After this change, tests will look for the source code in new subfolder based on the caller's environment (typically staging or prod). In addition, new images will be tagged with the caller's environment.