### PR TITLE
Allow folder_prefix to be empty

### DIFF
--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -13,23 +13,29 @@ class TestProjectStructure(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        source_folder = os.environ.get('FOLDER_NAME')
-        env_name = os.environ.get('ENV_NAME')
-        cls.source_folder_path = Path(f"/workspace/automation/source_data/{env_name}/{source_folder}")
+        source_folder = os.environ.get("FOLDER_NAME")
+        env_name = os.environ.get("ENV_NAME")
+        cls.source_folder_path = Path(
+            f"/workspace/automation/source_data/{env_name}/{source_folder}"
+        )
 
     def test_source_folder_include_python_script(self):
         """Checks if source folder contains a .py file."""
-        assert len([f for f in os.listdir(self.source_folder_path) if '.py' in str(f)]) > 0
+        assert (
+            len([f for f in os.listdir(self.source_folder_path) if ".py" in str(f)]) > 0
+        )
 
     def test_yaml_config_in_source_folder(self):
         """Check that source folder has a config.yaml file defining triggers."""
-        yaml_files = [f for f in os.listdir(self.source_folder_path) if 'config.yaml' in str(f)]
+        yaml_files = [
+            f for f in os.listdir(self.source_folder_path) if "config.yaml" in str(f)
+        ]
         # Check that config.yaml is in source directory
         assert len(yaml_files) == 1
-        with open(self.source_folder_path / Path(yaml_files[0]), 'r') as f:
+        with open(self.source_folder_path / Path(yaml_files[0]), "r") as f:
             data = yaml.safe_load(f)
         # Check that folder_prefix exclusively contains allowed chars
-        matches = re.findall(r"^[A-Za-z0-9-_./]+$", data['folder_prefix'])
+        matches = re.findall(r"^[A-Za-z0-9-_./]*$", data["folder_prefix"])
         assert len(matches) == 1
 
     def test_source_script_main_accepts_args(self):
@@ -41,9 +47,14 @@ class TestProjectStructure(unittest.TestCase):
         """
         files = os.listdir(self.source_folder_path)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            shutil.copytree('/workspace/dapla-source-data-processor-build-scripts/tests/test-plugins/',
-                            tmp_dir / Path('test-plugins/'))
+            shutil.copytree(
+                "/workspace/dapla-source-data-processor-build-scripts/tests/test-plugins/",
+                tmp_dir / Path("test-plugins/"),
+            )
             for file in files:
-                shutil.copy2(self.source_folder_path / Path(file), tmp_dir / Path('test-plugins/plugins'))
-            path_to_python_test = tmp_dir / Path('test-plugins/')
-            subprocess.run(['pytest'], cwd=path_to_python_test, check=True)
+                shutil.copy2(
+                    self.source_folder_path / Path(file),
+                    tmp_dir / Path("test-plugins/plugins"),
+                )
+            path_to_python_test = tmp_dir / Path("test-plugins/")
+            subprocess.run(["pytest"], cwd=path_to_python_test, check=True)


### PR DESCRIPTION
Many users want to be able to trigger on the root of the bucket. This works when setting `folder_prefix: ""` but our check fails. This PR fixes the check.

Includes black formatting, the functional change is in the regex on line 38.

Internal ref: STAT-719