### PR TITLE
This change adds support for manual triggering of the kildomaten workflow

### DIFF
--- a/.github/workflows/kildomaten.yaml
+++ b/.github/workflows/kildomaten.yaml
@@ -153,7 +153,7 @@ jobs:
       all_sources_deleted: ${{ steps.check_all_sources_deleted.outputs.all_sources_deleted }}
 
   test:
-    if: ${{ needs.workflow_gatekeeper.outputs.should_run_fetch_sources == 'true' && github.event_name != 'push' && needs.fetch_sources.outputs.matrix != '[]' }}
+    if: ${{ needs.workflow_gatekeeper.outputs.should_run_fetch_sources == 'true' && needs.fetch_sources.outputs.matrix != '[]' }}
     needs: [fetch_sources]
     runs-on: ubuntu-latest
     strategy:
@@ -276,7 +276,7 @@ jobs:
             atlantis/apply
 
   build_and_push:
-    if: ${{ github.event_name == 'push' && needs.fetch_sources.outputs.all_sources_deleted != 'true' && needs.fetch_sources.outputs.matrix != '[]' }}
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.fetch_sources.outputs.all_sources_deleted != 'true' && needs.fetch_sources.outputs.matrix != '[]' }}
     needs: [ fetch_sources ]
     runs-on: ubuntu-latest
     strategy:
@@ -321,9 +321,9 @@ jobs:
           docker push ${{ needs.fetch_sources.outputs.team_registry }}/$SOURCE_NAME:$PROJECT_NAME
 
   deploy_sources:
-    if: ${{ github.event_name == 'push' && needs.fetch_sources.outputs.matrix != '[]' }}
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch')  && needs.fetch_sources.outputs.matrix != '[]' && github.ref_name == github.event.repository.default_branch }}
     runs-on: ubuntu-latest
-    needs: [build_and_push, fetch_sources]
+    needs: [build_and_push, fetch_sources, test]
     strategy:
       matrix:
         source: ${{fromJson(needs.fetch_sources.outputs.matrix)}}


### PR DESCRIPTION
To allow for manual triggering of the workflow, workflow_dispatch will have to be enabled in the kildomaten workflow of every team iac repo.

```
on:
 workflow_dispatch:
```

**Notable changes**:

- Tests will now be required before deploying. This ensures that tests are run when triggering manually.
- Added a check that ref matches the default branch(main) in the deploy job. This is to stop builds with branches other than main(https://stackoverflow.com/questions/69260199/is-there-a-way-to-restrict-what-branch-an-action-can-be-run-on)