### PR TITLE
Update `kildomaten` feature activation check

### DIFF
--- a/.github/workflows/kildomaten.yaml
+++ b/.github/workflows/kildomaten.yaml
@@ -54,13 +54,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Confirm Activation of 'source-data-automation'
+      - name: Confirm Activation of 'kildomaten'
         run: |
-          result=$(yq e -o=json infra/projects.yaml | jq '.projects[] | select(.features | index("source-data-automation"))')
+          result=$(yq e -o=json infra/projects.yaml | jq '.projects[] | select(.features | index("kildomaten"))')
 
           if [ -z "$result" ]; then
-              echo "Error: The 'source-data-automation' feature is disabled for all projects."
-              exit 1
+            echo "Error: The 'kildomaten' feature is disabled for all projects."
+            exit 1
           fi
       - name: Set output variables
         id: step_output_variables


### PR DESCRIPTION
This now checks if the `Kilomaten` feature is enabled in projects.yaml, this change is needed to update the feature name.

Should not be merged before [template changes](https://github.com/statisticsnorway/cookiecutter-dapla-project-iac/pull/49) are merged and changes have been rolled out to teams with the feature enabled.